### PR TITLE
Update to latest rebuilt infrastructure

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,181 +2,166 @@ provider "aws" {
   region  = "eu-west-2"
   version = "~> 2.0"
 }
-
-provider "template" {
-  version = "~> 2.0"
+data "aws_iam_role" "ec2_container_service_role" {
+  name = "ecsServiceRole"
 }
-
+data "aws_iam_role" "ecs_task_execution_role" {
+  name = "ecsTaskExecutionRole"
+}
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+locals {
+  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
+}
 terraform {
   backend "s3" {
     bucket  = "hackney-mat-state-storage-s3"
     encrypt = true
     region  = "eu-west-2"
-    key     = "services/hc/state"
+    key     = "services/rebuild/hc/state"
   }
 }
-
-data "aws_iam_role" "ec2_container_service_role" {
-  name = "ecsServiceRole"
-}
-
-data "aws_iam_role" "ecs_task_execution_role" {
-  name = "ecsTaskExecutionRole"
-}
-
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
-
-locals {
-  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
-}
-
-module "development" {
-  # We pin to `master` for now, until we have tagged releases of the modules.
-  source = "github.com/LBHackney-IT/aws-mat-components-per-service-terraform.git//modules/environment/frontend?ref=master"
-
-  environment_name = "development"
-  application_name = "hc"
-
-  security_group_name_prefix = "mat-frontend-sg"
-  lb_prefix                  = "hackney-ext-mat-alb"
-
-  # Note that this process should only use ports in the 200X range to avoid port
-  # clashes.
-  port = 2001
-
-  listener_port = 80
-  path_pattern  = "/hc*"
-
+module "production" {
+  source                      = "github.com/LBHackney-IT/aws-hackney-components-per-service-terraform.git//modules/environment/frontend/fargate"
+  ecs_cluster                 = "mat" # Replace with your cluster name.
+  environment_name            = "production"
+  application_name            = "hc-process"    # Replace with your application name.
+  security_group_name         = "mat" # Replace with your security group name, WITHOUT SPECIFYING environment .
+  vpc_name                    = "vpc-mat"
+  port                        = 3000
   desired_number_of_ec2_nodes = 2
-
-  ecs_execution_role = "${data.aws_iam_role.ecs_task_execution_role.arn}"
-  lb_iam_role_arn    = "${data.aws_iam_role.ec2_container_service_role.arn}"
-
+  lb_prefix                   = "alb-mat"
+  ecs_execution_role          = data.aws_iam_role.ecs_task_execution_role.arn
+  lb_iam_role_arn             = data.aws_iam_role.ec2_container_service_role.arn
+  path_pattern                = "/hc*"
   task_definition_environment_variables = {
-    PROCESS_TYPE_VALUE = "100000152"
-    PROCESS_TYPE_NAME  = "Home Check"
-
-    PROCESS_API_HOST     = "4cgb2c6pqe.execute-api.eu-west-2.amazonaws.com"
-    PROCESS_API_BASE_URL = "/development/mat-process/api"
-
+    BASE_PATH = "/hc"
+    DIVERSITY_FORM_URL = "url.to.form"
+    ENVIRONMENT_NAME = "production"
+    MAT_API_BASE_URL = "/production/manage-a-tenancy-api"
     MAT_API_HOST     = "g6bw0g0ojk.execute-api.eu-west-2.amazonaws.com"
-    MAT_API_BASE_URL = "/development/manage-a-tenancy-api"
+    NODE_ENV = "production"
+    PROCESS_API_BASE_URL = "/production/process-api/api"
+    PROCESS_API_HOST     = "4edqo0pz1l.execute-api.eu-west-2.amazonaws.com"
+    PROCESS_NAME       = "hc"
+    PROCESS_TYPE_NAME  = "Household check"
+    PROCESS_TYPE_VALUE = "100000052"
+    WORKTRAY_URL = "https://services.hackney.gov.uk/manageatenancy/OfficerDashboard.aspx"
   }
-
-  task_definition_environment_variable_count = 6
-
-  task_definition_secrets = {
-    PROCESS_API_JWT_SECRET  = "${local.parameter_store}/development-hc-PROCESS_API_JWT_SECRET"
-    PROCESS_API_KEY         = "${local.parameter_store}/development-hc-PROCESS_API_KEY"
-    MAT_API_JWT_SECRET      = "${local.parameter_store}/development-hc-MAT_API_JWT_SECRET"
-    MAT_API_DATA_SHARED_KEY = "${local.parameter_store}/development-hc-MAT_API_DATA_SHARED_KEY"
-    MAT_API_DATA_SALT       = "${local.parameter_store}/development-hc-MAT_API_DATA_SALT"
-    MAT_API_DATA_ITERATIONS = "${local.parameter_store}/development-hc-MAT_API_DATA_ITERATIONS"
-    MAT_API_DATA_KEY_SIZE   = "${local.parameter_store}/development-hc-MAT_API_DATA_KEY_SIZE"
-    MAT_API_DATA_ALGORITHM  = "${local.parameter_store}/development-hc-MAT_API_DATA_ALGORITHM"
-    MAT_API_DATA_IV         = "${local.parameter_store}/development-hc-MAT_API_DATA_IV"
+  cost_code = "B0811"
+  task_definition_environment_variable_count = 12
+  task_definition_secrets      = { 
+    PROCESS_API_JWT_SECRET  = "${local.parameter_store}/production-thc-ROCESS_API_JWT_SECRET"
+    PROCESS_API_KEY         = "${local.parameter_store}/production-thc-PROCESS_API_KEY"
+    MAT_API_JWT_SECRET      = "${local.parameter_store}/production-thc-MAT_API_JWT_SECRET"
+    MAT_API_DATA_SHARED_KEY = "${local.parameter_store}/production-thc-MAT_API_DATA_SHARED_KEY"
+    MAT_API_DATA_SALT       = "${local.parameter_store}/production-thc-MAT_API_DATA_SALT"
+    MAT_API_DATA_ITERATIONS = "${local.parameter_store}/production-thc-MAT_API_DATA_ITERATIONS"
+    MAT_API_DATA_KEY_SIZE   = "${local.parameter_store}/production-thc-MAT_API_DATA_KEY_SIZE"
+    MAT_API_DATA_ALGORITHM  = "${local.parameter_store}/production-thc-MAT_API_DATA_ALGORITHM"
+    MAT_API_DATA_IV         = "${local.parameter_store}/production-thc-MAT_API_DATA_IV"
   }
-
   task_definition_secret_count = 9
+
+   protocol         = "HTTP"
+   listener_http_port = 80
 }
 
 module "staging" {
-  # We pin to `master` for now, until we have tagged releases of the modules.
-  source = "github.com/LBHackney-IT/aws-mat-components-per-service-terraform.git//modules/environment/frontend?ref=master"
-
-  environment_name = "staging"
-  application_name = "hc"
-
-  security_group_name_prefix = "mat-frontend-sg"
-  lb_prefix                  = "hackney-ext-mat-alb"
-
-  # Note that this process should only use ports in the 200X range to avoid port
-  # clashes.
-  port = 2002
-
-  listener_port = 80
-  path_pattern  = "/hc*"
-
+  source                      = "github.com/LBHackney-IT/aws-hackney-components-per-service-terraform.git//modules/environment/frontend/fargate"
+  ecs_cluster                 = "mat" # Replace with your cluster name.
+  environment_name            = "staging"
+  application_name            = "hc-process"    # Replace with your application name.
+  security_group_name         = "mat" # Replace with your security group name, WITHOUT SPECIFYING environment .
+  vpc_name                    = "vpc-mat"
+  port                        = 3001
   desired_number_of_ec2_nodes = 2
-
-  ecs_execution_role = "${data.aws_iam_role.ecs_task_execution_role.arn}"
-  lb_iam_role_arn    = "${data.aws_iam_role.ec2_container_service_role.arn}"
-
+  lb_prefix                   = "alb-mat"
+  ecs_execution_role          = data.aws_iam_role.ecs_task_execution_role.arn
+  lb_iam_role_arn             = data.aws_iam_role.ec2_container_service_role.arn
+  path_pattern                = "/hc*"
   task_definition_environment_variables = {
-    PROCESS_TYPE_VALUE = "100000152"
-    PROCESS_TYPE_NAME  = "Home Check"
-
-    PROCESS_API_HOST     = "dg5hz8mgwc.execute-api.eu-west-2.amazonaws.com"
-    PROCESS_API_BASE_URL = "/staging/mat-process/api"
-
-    MAT_API_HOST     = "g6bw0g0ojk.execute-api.eu-west-2.amazonaws.com"
+    BASE_PATH = "/hc"
+    DIVERSITY_FORM_URL = "url.to.form"
+    ENVIRONMENT_NAME = "staging"
     MAT_API_BASE_URL = "/staging/manage-a-tenancy-api"
-  }
-
-  task_definition_environment_variable_count = 6
-
-  task_definition_secrets = {
-    PROCESS_API_JWT_SECRET  = "${local.parameter_store}/staging-hc-PROCESS_API_JWT_SECRET"
-    PROCESS_API_KEY         = "${local.parameter_store}/staging-hc-PROCESS_API_KEY"
-    MAT_API_JWT_SECRET      = "${local.parameter_store}/staging-hc-MAT_API_JWT_SECRET"
-    MAT_API_DATA_SHARED_KEY = "${local.parameter_store}/staging-hc-MAT_API_DATA_SHARED_KEY"
-    MAT_API_DATA_SALT       = "${local.parameter_store}/staging-hc-MAT_API_DATA_SALT"
-    MAT_API_DATA_ITERATIONS = "${local.parameter_store}/staging-hc-MAT_API_DATA_ITERATIONS"
-    MAT_API_DATA_KEY_SIZE   = "${local.parameter_store}/staging-hc-MAT_API_DATA_KEY_SIZE"
-    MAT_API_DATA_ALGORITHM  = "${local.parameter_store}/staging-hc-MAT_API_DATA_ALGORITHM"
-    MAT_API_DATA_IV         = "${local.parameter_store}/staging-hc-MAT_API_DATA_IV"
-  }
-
-  task_definition_secret_count = 9
-}
-
-module "production" {
-  # We pin to `master` for now, until we have tagged releases of the modules.
-  source = "github.com/LBHackney-IT/aws-mat-components-per-service-terraform.git//modules/environment/frontend?ref=master"
-
-  environment_name = "production"
-  application_name = "hc"
-
-  security_group_name_prefix = "mat-frontend-sg"
-  lb_prefix                  = "hackney-ext-mat-alb"
-
-  # Note that this process should only use ports in the 200X range to avoid port
-  # clashes.
-  port = 2000
-
-  listener_port = 80
-  path_pattern  = "/hc*"
-
-  desired_number_of_ec2_nodes = 2
-
-  ecs_execution_role = "${data.aws_iam_role.ecs_task_execution_role.arn}"
-  lb_iam_role_arn    = "${data.aws_iam_role.ec2_container_service_role.arn}"
-
-  task_definition_environment_variables = {
-    PROCESS_TYPE_VALUE = "100000152"
-    PROCESS_TYPE_NAME  = "Home Check"
-
-    PROCESS_API_HOST     = "n74li4pi4k.execute-api.eu-west-2.amazonaws.com"
-    PROCESS_API_BASE_URL = "/production/mat-process/api"
-
     MAT_API_HOST     = "g6bw0g0ojk.execute-api.eu-west-2.amazonaws.com"
-    MAT_API_BASE_URL = "/production/manage-a-tenancy-api"
+    NODE_ENV = "production"
+    PROCESS_API_BASE_URL = "/staging/process-api/api"
+    PROCESS_API_HOST     = "hvlo6az3t2.execute-api.eu-west-2.amazonaws.com"
+    PROCESS_NAME       = "hc"
+    PROCESS_TYPE_NAME  = "Household check"
+    PROCESS_TYPE_VALUE = "100000052"
+    WORKTRAY_URL = "https://hlbctrial-tst.outsystemsenterprise.com/manageatenancy/OfficerDashboard.aspx"
   }
+  cost_code = "B0811"
+  task_definition_environment_variable_count = 12
 
-  task_definition_environment_variable_count = 6
-
-  task_definition_secrets = {
-    PROCESS_API_JWT_SECRET  = "${local.parameter_store}/production-hc-PROCESS_API_JWT_SECRET"
-    PROCESS_API_KEY         = "${local.parameter_store}/production-hc-PROCESS_API_KEY"
-    MAT_API_JWT_SECRET      = "${local.parameter_store}/production-hc-MAT_API_JWT_SECRET"
-    MAT_API_DATA_SHARED_KEY = "${local.parameter_store}/production-hc-MAT_API_DATA_SHARED_KEY"
-    MAT_API_DATA_SALT       = "${local.parameter_store}/production-hc-MAT_API_DATA_SALT"
-    MAT_API_DATA_ITERATIONS = "${local.parameter_store}/production-hc-MAT_API_DATA_ITERATIONS"
-    MAT_API_DATA_KEY_SIZE   = "${local.parameter_store}/production-hc-MAT_API_DATA_KEY_SIZE"
-    MAT_API_DATA_ALGORITHM  = "${local.parameter_store}/production-hc-MAT_API_DATA_ALGORITHM"
-    MAT_API_DATA_IV         = "${local.parameter_store}/production-hc-MAT_API_DATA_IV"
+  task_definition_secrets      = { 
+    PROCESS_API_JWT_SECRET  = "${local.parameter_store}/development-thc-ROCESS_API_JWT_SECRET"
+    PROCESS_API_KEY         = "${local.parameter_store}/development-thc-PROCESS_API_KEY"
+    MAT_API_JWT_SECRET      = "${local.parameter_store}/development-thc-MAT_API_JWT_SECRET"
+    MAT_API_DATA_SHARED_KEY = "${local.parameter_store}/development-thc-MAT_API_DATA_SHARED_KEY"
+    MAT_API_DATA_SALT       = "${local.parameter_store}/development-thc-MAT_API_DATA_SALT"
+    MAT_API_DATA_ITERATIONS = "${local.parameter_store}/development-thc-MAT_API_DATA_ITERATIONS"
+    MAT_API_DATA_KEY_SIZE   = "${local.parameter_store}/development-thc-MAT_API_DATA_KEY_SIZE"
+    MAT_API_DATA_ALGORITHM  = "${local.parameter_store}/development-thc-MAT_API_DATA_ALGORITHM"
+    MAT_API_DATA_IV         = "${local.parameter_store}/development-thc-MAT_API_DATA_IV"
   }
-
   task_definition_secret_count = 9
+
+  protocol         = "HTTP"
+  listener_http_port = 80
 }
+
+module "development" {
+  source                      = "github.com/LBHackney-IT/aws-hackney-components-per-service-terraform.git//modules/environment/frontend/fargate"
+  ecs_cluster                 = "mat" # Replace with your cluster name.
+  environment_name            = "development"
+  application_name            = "hc-process"    # Replace with your application name.
+  security_group_name         = "mat" # Replace with your security group name, WITHOUT SPECIFYING environment .
+  vpc_name                    = "vpc-mat"
+  port                        = 3002
+  desired_number_of_ec2_nodes = 2
+  lb_prefix                   = "alb-mat"
+  ecs_execution_role          = data.aws_iam_role.ecs_task_execution_role.arn
+  lb_iam_role_arn             = data.aws_iam_role.ec2_container_service_role.arn
+  path_pattern                = "/hc*"
+  task_definition_environment_variables = {
+    BASE_PATH = "/hc"
+    DIVERSITY_FORM_URL = "url.to.form"
+    ENVIRONMENT_NAME = "development"
+    MAT_API_BASE_URL = "/development/manage-a-tenancy-api"
+    MAT_API_HOST = "g6bw0g0ojk.execute-api.eu-west-2.amazonaws.com"
+    NODE_ENV = "production"
+    PROCESS_API_BASE_URL = "/development/mat-process/api"
+    PROCESS_API_HOST = "4cgb2c6pqe.execute-api.eu-west-2.amazonaws.com"
+    PROCESS_NAME = "hc"
+    PROCESS_TYPE_NAME = "Household check"
+    PROCESS_TYPE_VALUE = "100000052"
+    WORKTRAY_URL = "https://hlbctrial-dev.outsystemsenterprise.com/manageatenancy/OfficerDashboard.aspx"
+  }
+
+  cost_code = "B0811"
+  task_definition_environment_variable_count = 12
+
+  task_definition_secrets      = { 
+    PROCESS_API_JWT_SECRET  = "${local.parameter_store}/development-thc-ROCESS_API_JWT_SECRET"
+    PROCESS_API_KEY         = "${local.parameter_store}/development-thc-PROCESS_API_KEY"
+    MAT_API_JWT_SECRET      = "${local.parameter_store}/development-thc-MAT_API_JWT_SECRET"
+    MAT_API_DATA_SHARED_KEY = "${local.parameter_store}/development-thc-MAT_API_DATA_SHARED_KEY"
+    MAT_API_DATA_SALT       = "${local.parameter_store}/development-thc-MAT_API_DATA_SALT"
+    MAT_API_DATA_ITERATIONS = "${local.parameter_store}/development-thc-MAT_API_DATA_ITERATIONS"
+    MAT_API_DATA_KEY_SIZE   = "${local.parameter_store}/development-thc-MAT_API_DATA_KEY_SIZE"
+    MAT_API_DATA_ALGORITHM  = "${local.parameter_store}/development-thc-MAT_API_DATA_ALGORITHM"
+    MAT_API_DATA_IV         = "${local.parameter_store}/development-thc-MAT_API_DATA_IV"
+  }
+  
+  task_definition_secret_count = 9
+
+   protocol         = "HTTP"
+   listener_http_port = 80
+}
+/*   ADD ANY OTHER CUSTOM RESOURCES REQUIRED HERE      */
+
+#


### PR DESCRIPTION
Update terraform file to support newly rebuilt backend infrastructure

# What?

Development, staging and production modules for hc front end

# Why?

Updated to be inline with the newly rebuilt backend infrastructure

# Notes

Development environment is still pointing to "old" development cluster so it's inline with the THC process. These can be swapped over to new cluster at later date.
